### PR TITLE
Add exceptionClass as extra header

### DIFF
--- a/src/main/java/com/teambytes/logback/flume/FlumeLogstashV1Appender.java
+++ b/src/main/java/com/teambytes/logback/flume/FlumeLogstashV1Appender.java
@@ -1,6 +1,7 @@
 package com.teambytes.logback.flume;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import org.apache.commons.lang.StringUtils;
@@ -211,6 +212,11 @@ public class FlumeLogstashV1Appender extends UnsynchronizedAppenderBase<ILogging
 
     if (StringUtils.isNotEmpty(type)) {
       headers.put("type", type);
+    }
+
+    IThrowableProxy throwable = eventObject.getThrowableProxy();
+    if(throwable != null) {
+      headers.put("exceptionClass", throwable.getClassName());
     }
 
     return headers;


### PR DESCRIPTION
It is very useful to quickly filter through all the logs to get ONLY
the exceptions. By putting the exceptionClass as separate Avro header
it can be then easily exported to indexes (e.g. ElasticSearch) and searched
as 'exceptionClass:*'.